### PR TITLE
PR #1: Baseline Sandbox Environment

### DIFF
--- a/scripts/verify-alcless.sh
+++ b/scripts/verify-alcless.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# scripts/verify-alcless.sh
+
+echo "--- Alcless Baseline Verification ---"
+
+# 1. Check if alclessctl is in PATH
+if ! command -v alclessctl &> /dev/null; then
+    echo "Error: alclessctl is not installed or not in PATH."
+    echo "Please install it by running:"
+    echo "  git clone https://github.com/AkihiroSuda/alcless"
+    echo "  cd alcless && make && sudo make install"
+    exit 1
+fi
+
+echo "Success: alclessctl is installed."
+
+# 2. Check alcless version
+VERSION=$(alclessctl --version)
+echo "Alcless Version: $VERSION"
+
+# 3. Check if 'default' sandbox exists
+echo "Checking for 'default' sandbox..."
+if alclessctl ls | grep -q "default"; then
+    echo "Success: 'default' sandbox exists."
+else
+    echo "Warning: 'default' sandbox not found."
+    echo "Please create it by running: alclessctl create default"
+    exit 1
+fi
+
+# 4. Try to run whoami in the sandbox
+echo "Testing sandbox execution (requires sudo access)..."
+SANDBOX_USER=$(alclessctl shell default -- whoami 2>/dev/null)
+
+if [ $? -eq 0 ]; then
+    echo "Success: Sandbox user is $SANDBOX_USER"
+else
+    echo "Error: Could not execute command in sandbox."
+    echo "Ensure your user has NOPASSWD sudo access for alcless commands as per README."
+    exit 1
+fi
+
+echo "--- Verification Complete ---"


### PR DESCRIPTION
## Summary
* Added `scripts/verify-alcless.sh` to automate the verification of the `alcless` installation and configuration.
* This script checks for the presence of `alclessctl`, the existence of the `default` sandbox, and tests sandbox execution.

## Verification
1. Install `alcless` manually (requires sudo):
   ```bash
   git clone https://github.com/AkihiroSuda/alcless
   cd alcless && make && sudo make install
   alclessctl create default
   ```
2. Run the verification script:
   ```bash
   ./scripts/verify-alcless.sh
   ```