### PR TITLE
PR #2: Secret Injection & GH Authentication

### DIFF
--- a/scripts/verify-alcless.sh
+++ b/scripts/verify-alcless.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# scripts/verify-alcless.sh
+
+echo "--- Alcless Baseline Verification ---"
+
+# 1. Check if alclessctl is in PATH
+if ! command -v alclessctl &> /dev/null; then
+    echo "Error: alclessctl is not installed or not in PATH."
+    echo "Please install it by running:"
+    echo "  git clone https://github.com/AkihiroSuda/alcless"
+    echo "  cd alcless && make && sudo make install"
+    exit 1
+fi
+
+echo "Success: alclessctl is installed."
+
+# 2. Check alcless version
+VERSION=$(alclessctl --version)
+echo "Alcless Version: $VERSION"
+
+# 3. Check if 'default' sandbox exists
+echo "Checking for 'default' sandbox..."
+if alclessctl ls | grep -q "default"; then
+    echo "Success: 'default' sandbox exists."
+else
+    echo "Warning: 'default' sandbox not found."
+    echo "Please create it by running: alclessctl create default"
+    exit 1
+fi
+
+# 4. Try to run whoami in the sandbox
+echo "Testing sandbox execution (requires sudo access)..."
+SANDBOX_USER=$(alclessctl shell default -- whoami 2>/dev/null)
+
+if [ $? -eq 0 ]; then
+    echo "Success: Sandbox user is $SANDBOX_USER"
+else
+    echo "Error: Could not execute command in sandbox."
+    echo "Ensure your user has NOPASSWD sudo access for alcless commands as per README."
+    exit 1
+fi
+
+echo "--- Verification Complete ---"

--- a/scripts/verify-gh-auth.ts
+++ b/scripts/verify-gh-auth.ts
@@ -1,0 +1,61 @@
+import { spawn } from 'bun';
+
+/**
+ * scripts/verify-gh-auth.ts
+ *
+ * Verifies that GH_TOKEN is correctly passed into the alcless sandbox.
+ * Usage: GH_TOKEN=your_token bun scripts/verify-gh-auth.ts
+ */
+
+async function main() {
+  const token = process.env.GH_TOKEN;
+  if (!token) {
+    console.error('Error: GH_TOKEN environment variable is not set.');
+    process.exit(1);
+  }
+
+  console.log('--- Verifying GH Auth in Sandbox ---');
+
+  // We use alclessctl shell --plain default -- gh auth status
+  // We first check if gh is available
+  const checkGh = ['alclessctl', 'shell', '--plain', 'default', '--', 'which', 'gh'];
+
+  console.log('Checking for gh CLI in sandbox...');
+  const checkProc = spawn(checkGh, { stdout: 'pipe', stderr: 'pipe' });
+  const checkExitCode = await checkProc.exited;
+
+  if (checkExitCode !== 0) {
+    console.log('gh CLI not found in sandbox. You may need to install it first:');
+    console.log('  alclessctl shell default -- brew install gh');
+    process.exit(1);
+  }
+
+  const command = ['alclessctl', 'shell', '--plain', 'default', '--', 'sh', '-c', 'gh auth status'];
+
+  console.log(`Executing: ${command.join(' ')}`);
+
+  const proc = spawn(command, {
+    stdout: 'inherit',
+    stderr: 'inherit',
+    env: {
+      ...process.env,
+      GH_TOKEN: token,
+    },
+  });
+
+  const exitCode = await proc.exited;
+
+  if (exitCode === 0) {
+    console.log('\nSuccess: GitHub CLI is authenticated inside the sandbox!');
+  } else {
+    console.error('\nError: GitHub CLI authentication failed.');
+    console.error('Possible reasons:');
+    console.error('1. alcless is not installed or configured.');
+    console.error('2. gh CLI is not installed in the sandbox user environment.');
+    console.error('3. GH_TOKEN is invalid.');
+  }
+
+  process.exit(exitCode);
+}
+
+main();


### PR DESCRIPTION
## Summary
* Added `scripts/verify-gh-auth.ts` to verify environment variable injection into the sandbox.
* This confirms that `GH_TOKEN` is correctly passed to the sandboxed processes, allowing tools like `gh` to authenticate.

## Verification
1. Ensure `alcless` is installed and the `default` sandbox is created (see PR #1).
2. Install `gh` in the sandbox (if not already present):
   ```bash
   alclessctl shell default -- brew install gh
   ```
3. Run the verification script with a valid `GH_TOKEN`:
   ```bash
   GH_TOKEN=your_pat_token bun scripts/verify-gh-auth.ts
   ```