### PR TITLE
PR #3: Host-Side Bridge & Shims

### DIFF
--- a/scripts/verify-host-shim.ts
+++ b/scripts/verify-host-shim.ts
@@ -11,26 +11,38 @@ async function main() {
   }
   mkdirSync(workspace, { recursive: true });
   chmodSync(workspace, 0o777); // Ensure everyone can access
-  
-  const manager = new SandboxManager(workspace);
 
-  console.log('--- Testing Host Bridge & Shims ---');
+  const sandboxToken = process.env.SANDBOX_GH_TOKEN;
+  if (!sandboxToken) {
+    console.error('Error: SANDBOX_GH_TOKEN not found in environment.');
+    process.exit(1);
+  }
+
+  const manager = new SandboxManager(workspace, sandboxToken);
+
+  console.log('--- Testing Host Bridge & Dedicated Secret Isolation ---');
+  console.log(`Using dedicated token: ${sandboxToken.substring(0, 15)}...`);
 
   await manager.start();
   const sandboxBin = join(workspace, '.bin');
   manager.setupShims(sandboxBin);
 
-  // Set up dummy GH_TOKEN
-  process.env.GH_TOKEN = 'mock_token_123';
+  // Set up a DIFFENT dummy GH_TOKEN for the host
+  process.env.GH_TOKEN = 'host_primary_token_should_not_be_used';
 
   console.log('Running sandboxed gh command via shim...');
-  
+
   // Simulate what a sandboxed process would do:
   // Use alclessctl to run the shim
   const cmd = [
-    'alclessctl', 'shell', '--plain', 'default',
+    'alclessctl',
+    'shell',
+    '--plain',
+    'default',
     '--',
-    'sh', '-c', `export PATH="${sandboxBin}:$PATH"; gh auth status`
+    'sh',
+    '-c',
+    `export PATH="${sandboxBin}:$PATH"; gh auth status`,
   ];
 
   console.log(`Executing: ${cmd.join(' ')}`);
@@ -41,9 +53,9 @@ async function main() {
   });
 
   const exitCode = await proc.exited;
-  
+
   console.log(`\nExit code: ${exitCode}`);
-  
+
   if (exitCode === 0) {
     console.log('Success: Bridge handled the request and returned output!');
   } else {
@@ -52,9 +64,14 @@ async function main() {
 
   console.log('\nVerifying GH_TOKEN is NOT in sandbox environment...');
   const envCmd = [
-    'alclessctl', 'shell', '--plain', 'default',
+    'alclessctl',
+    'shell',
+    '--plain',
+    'default',
     '--',
-    'sh', '-c', 'env | grep GH_TOKEN || echo "GH_TOKEN not found (Good)"'
+    'sh',
+    '-c',
+    'env | grep GH_TOKEN || echo "GH_TOKEN not found (Good)"',
   ];
   await spawn(envCmd, { stdout: 'inherit', stderr: 'inherit' }).exited;
 

--- a/scripts/verify-host-shim.ts
+++ b/scripts/verify-host-shim.ts
@@ -1,0 +1,65 @@
+import { SandboxManager } from '../src/sandbox/manager';
+import { spawn } from 'bun';
+import { join } from 'path';
+import { existsSync, mkdirSync, chmodSync } from 'fs';
+
+async function main() {
+  const workspace = '/Users/Shared/test-bridge-workspace';
+  if (existsSync(workspace)) {
+    // rm -rf
+    await spawn(['rm', '-rf', workspace]).exited;
+  }
+  mkdirSync(workspace, { recursive: true });
+  chmodSync(workspace, 0o777); // Ensure everyone can access
+  
+  const manager = new SandboxManager(workspace);
+
+  console.log('--- Testing Host Bridge & Shims ---');
+
+  await manager.start();
+  const sandboxBin = join(workspace, '.bin');
+  manager.setupShims(sandboxBin);
+
+  // Set up dummy GH_TOKEN
+  process.env.GH_TOKEN = 'mock_token_123';
+
+  console.log('Running sandboxed gh command via shim...');
+  
+  // Simulate what a sandboxed process would do:
+  // Use alclessctl to run the shim
+  const cmd = [
+    'alclessctl', 'shell', '--plain', 'default',
+    '--',
+    'sh', '-c', `export PATH="${sandboxBin}:$PATH"; gh auth status`
+  ];
+
+  console.log(`Executing: ${cmd.join(' ')}`);
+
+  const proc = spawn(cmd, {
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+
+  const exitCode = await proc.exited;
+  
+  console.log(`\nExit code: ${exitCode}`);
+  
+  if (exitCode === 0) {
+    console.log('Success: Bridge handled the request and returned output!');
+  } else {
+    console.log('Failed: Check bridge logs above.');
+  }
+
+  console.log('\nVerifying GH_TOKEN is NOT in sandbox environment...');
+  const envCmd = [
+    'alclessctl', 'shell', '--plain', 'default',
+    '--',
+    'sh', '-c', 'env | grep GH_TOKEN || echo "GH_TOKEN not found (Good)"'
+  ];
+  await spawn(envCmd, { stdout: 'inherit', stderr: 'inherit' }).exited;
+
+  manager.stop();
+  process.exit(exitCode);
+}
+
+main();

--- a/src/opencode.ts
+++ b/src/opencode.ts
@@ -59,7 +59,7 @@ export class OpenCodeAgent extends EventEmitter implements Agent {
   }
 
   async start(prompt?: string) {
-    let args = ['run', '--format', 'json'];
+    const args = ['run', '--format', 'json'];
 
     if (this.sessionId) {
       args.push('--session', this.sessionId);
@@ -72,7 +72,7 @@ export class OpenCodeAgent extends EventEmitter implements Agent {
     const commandPath = process.env.OPENCODE_BINARY || '/opt/homebrew/bin/opencode';
 
     let spawnArgs: string[];
-    let spawnEnv = { ...process.env };
+    const spawnEnv = { ...process.env };
 
     if (this.useSandbox) {
       // Wrap with alclessctl

--- a/src/opencode.ts
+++ b/src/opencode.ts
@@ -21,6 +21,12 @@ export interface OpenCodeEvent {
   };
 }
 
+export interface OpenCodeAgentOptions {
+  workspacePath?: string;
+  useSandbox?: boolean;
+  sandboxBinDir?: string;
+}
+
 /**
  * OpenCode Agent: Spawns a new process for every turn (Stable Persistence).
  * Reuses the same session ID to preserve context via OpenCode's database.
@@ -32,9 +38,19 @@ export class OpenCodeAgent extends EventEmitter implements Agent {
   private stderrPath: string;
   private lastActivity: number = Date.now();
   private heartbeatTimer: Timer | null = null;
+  private workspacePath: string;
+  private useSandbox: boolean;
+  private sandboxBinDir?: string;
 
-  constructor(private sessionId?: string) {
+  constructor(
+    private sessionId?: string,
+    options: OpenCodeAgentOptions = {},
+  ) {
     super();
+    this.workspacePath = options.workspacePath || process.cwd();
+    this.useSandbox = options.useSandbox || false;
+    this.sandboxBinDir = options.sandboxBinDir;
+
     if (!existsSync('logs')) mkdirSync('logs');
     const logId = this.sessionId || `temp_${Date.now()}`;
     const turnId = Date.now();
@@ -43,7 +59,7 @@ export class OpenCodeAgent extends EventEmitter implements Agent {
   }
 
   async start(prompt?: string) {
-    const args = ['run', '--format', 'json'];
+    let args = ['run', '--format', 'json'];
 
     if (this.sessionId) {
       args.push('--session', this.sessionId);
@@ -53,17 +69,37 @@ export class OpenCodeAgent extends EventEmitter implements Agent {
       args.push(prompt);
     }
 
-    const commandPath = '/opt/homebrew/bin/opencode';
-    console.log(`[Agent] Spawning: ${commandPath} ${args.join(' ')}`);
+    const commandPath = process.env.OPENCODE_BINARY || '/opt/homebrew/bin/opencode';
+
+    let spawnArgs: string[];
+    let spawnEnv = { ...process.env };
+
+    if (this.useSandbox) {
+      // Wrap with alclessctl
+      // We use --plain to avoid rsyncing, and manage the workspace manually
+      const sandboxCommand = [
+        'alclessctl',
+        'shell',
+        '--plain',
+        'default',
+        '--',
+        'sh',
+        '-c',
+        `cd "${this.workspacePath}" && export PATH="${this.sandboxBinDir}:$PATH" && "${commandPath}" ${args.map((a) => `"${a}"`).join(' ')}`,
+      ];
+      spawnArgs = sandboxCommand;
+      console.log(`[Agent] Sandboxed Spawning: ${spawnArgs.join(' ')}`);
+    } else {
+      spawnArgs = [commandPath, ...args];
+      console.log(`[Agent] Spawning: ${spawnArgs.join(' ')}`);
+    }
 
     try {
-      this.process = spawn([commandPath, ...args], {
+      this.process = spawn(spawnArgs, {
         stdout: 'pipe',
         stderr: 'pipe',
         stdin: null,
-        env: {
-          ...process.env,
-        },
+        env: spawnEnv,
       });
 
       console.log(`[Agent] PID: ${this.process.pid}`);

--- a/src/sandbox/bridge.ts
+++ b/src/sandbox/bridge.ts
@@ -1,0 +1,123 @@
+import { listen } from 'bun';
+import { spawn } from 'bun';
+import { existsSync, unlinkSync, mkdirSync, chmodSync } from 'fs';
+import { join } from 'path';
+
+export interface BridgeRequest {
+  command: string;
+  args: string[];
+  cwd: string;
+  env?: Record<string, string>;
+}
+
+export class HostBridge {
+  private listener: any = null;
+  private socketPath: string;
+
+  constructor(workspacePath: string) {
+    if (!existsSync(workspacePath)) {
+      mkdirSync(workspacePath, { recursive: true });
+    }
+    this.socketPath = join(workspacePath, 'bridge.sock');
+  }
+
+  async start() {
+    if (existsSync(this.socketPath)) {
+      unlinkSync(this.socketPath);
+    }
+
+    console.log(`[Bridge] Starting on ${this.socketPath}...`);
+
+    this.listener = listen({
+      unix: this.socketPath,
+      socket: {
+        data: async (socket, data) => {
+          try {
+            const request: BridgeRequest = JSON.parse(data.toString());
+            await this.handleRequest(socket, request);
+          } catch (error) {
+            console.error('[Bridge] Error handling data:', error);
+            socket.write(JSON.stringify({ type: 'error', message: String(error) }));
+            socket.end();
+          }
+        },
+        error: (socket, error) => {
+          console.error('[Bridge] Socket error:', error);
+        },
+      },
+    });
+
+    // Ensure the socket is accessible by the sandbox user
+    chmodSync(this.socketPath, 0o777);
+  }
+
+  private async handleRequest(socket: any, request: BridgeRequest) {
+    console.log(
+      `[Bridge] Executing: ${request.command} ${request.args.join(' ')} (cwd: ${request.cwd})`,
+    );
+
+    // Whitelist check
+    const allowedCommands = ['gh', 'git'];
+    if (!allowedCommands.includes(request.command)) {
+      socket.write(
+        JSON.stringify({ type: 'error', message: `Command ${request.command} not allowed` }),
+      );
+      socket.end();
+      return;
+    }
+
+    const commandPath = request.command;
+
+    try {
+      const proc = spawn([commandPath, ...request.args], {
+        // For now, let's use the current dir of the bridge if the requested cwd is invalid on host
+        cwd: existsSync(request.cwd) ? request.cwd : process.cwd(),
+        env: {
+          ...process.env,
+          ...request.env,
+        },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+
+      // Stream stdout
+      const stdoutReader = this.streamToSocket(proc.stdout, socket, 'stdout');
+      // Stream stderr
+      const stderrReader = this.streamToSocket(proc.stderr, socket, 'stderr');
+
+      const exitCode = await proc.exited;
+      await Promise.all([stdoutReader, stderrReader]);
+
+      socket.write(JSON.stringify({ type: 'exit', code: exitCode }));
+      socket.end();
+    } catch (error) {
+      console.error('[Bridge] Execution error:', error);
+      socket.write(JSON.stringify({ type: 'error', message: String(error) }));
+      socket.end();
+    }
+  }
+
+  private async streamToSocket(stream: ReadableStream, socket: any, type: 'stdout' | 'stderr') {
+    const reader = stream.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        socket.write(JSON.stringify({ type, data: Buffer.from(value).toString('base64') }) + '\n');
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  stop() {
+    this.listener?.stop();
+    if (existsSync(this.socketPath)) {
+      unlinkSync(this.socketPath);
+    }
+  }
+
+  getSocketPath() {
+    return this.socketPath;
+  }
+}

--- a/src/sandbox/bridge.ts
+++ b/src/sandbox/bridge.ts
@@ -13,12 +13,14 @@ export interface BridgeRequest {
 export class HostBridge {
   private listener: any = null;
   private socketPath: string;
+  private sandboxToken?: string;
 
-  constructor(workspacePath: string) {
+  constructor(workspacePath: string, sandboxToken?: string) {
     if (!existsSync(workspacePath)) {
       mkdirSync(workspacePath, { recursive: true });
     }
     this.socketPath = join(workspacePath, 'bridge.sock');
+    this.sandboxToken = sandboxToken;
   }
 
   async start() {
@@ -75,6 +77,7 @@ export class HostBridge {
         env: {
           ...process.env,
           ...request.env,
+          GH_TOKEN: this.sandboxToken || process.env.SANDBOX_GH_TOKEN || process.env.GH_TOKEN,
         },
         stdout: 'pipe',
         stderr: 'pipe',

--- a/src/sandbox/bridge.ts
+++ b/src/sandbox/bridge.ts
@@ -1,4 +1,4 @@
-import { listen } from 'bun';
+import { listen, type Socket, type SocketListener } from 'bun';
 import { spawn } from 'bun';
 import { existsSync, unlinkSync, mkdirSync, chmodSync } from 'fs';
 import { join } from 'path';
@@ -11,7 +11,7 @@ export interface BridgeRequest {
 }
 
 export class HostBridge {
-  private listener: any = null;
+  private listener: SocketListener<unknown> | null = null;
   private socketPath: string;
   private sandboxToken?: string;
 
@@ -53,7 +53,7 @@ export class HostBridge {
     chmodSync(this.socketPath, 0o777);
   }
 
-  private async handleRequest(socket: any, request: BridgeRequest) {
+  private async handleRequest(socket: Socket<unknown>, request: BridgeRequest) {
     console.log(
       `[Bridge] Executing: ${request.command} ${request.args.join(' ')} (cwd: ${request.cwd})`,
     );
@@ -100,7 +100,11 @@ export class HostBridge {
     }
   }
 
-  private async streamToSocket(stream: ReadableStream, socket: any, type: 'stdout' | 'stderr') {
+  private async streamToSocket(
+    stream: ReadableStream,
+    socket: Socket<unknown>,
+    type: 'stdout' | 'stderr',
+  ) {
     const reader = stream.getReader();
     try {
       while (true) {

--- a/src/sandbox/manager.ts
+++ b/src/sandbox/manager.ts
@@ -1,0 +1,53 @@
+import { writeFileSync, chmodSync, mkdirSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { HostBridge } from './bridge';
+
+export class SandboxManager {
+  private bridge: HostBridge;
+  private workspacePath: string;
+
+  constructor(workspacePath: string) {
+    this.workspacePath = workspacePath;
+    this.bridge = new HostBridge(workspacePath);
+  }
+
+  async start() {
+    await this.bridge.start();
+  }
+
+  stop() {
+    this.bridge.stop();
+  }
+
+  getSocketPath() {
+    return this.bridge.getSocketPath();
+  }
+
+  /**
+   * Creates shim scripts in the specified directory.
+   */
+  setupShims(targetBinDir: string) {
+    if (!existsSync(targetBinDir)) {
+      mkdirSync(targetBinDir, { recursive: true });
+    }
+
+    const tools = ['gh', 'git'];
+    const shimSourcePath = join(__dirname, 'shim.py');
+    const shimDestPath = join(targetBinDir, 'shim.py');
+
+    // Copy shim.py to target bin dir
+    const shimContent = readFileSync(shimSourcePath);
+    writeFileSync(shimDestPath, shimContent);
+    chmodSync(shimDestPath, 0o755);
+
+    for (const tool of tools) {
+      const shimPath = join(targetBinDir, tool);
+      const content = `#!/bin/bash
+BRIDGE_SOCK="${this.getSocketPath()}" SHIM_COMMAND="${tool}" /usr/bin/python3 "${shimDestPath}" "$@"
+`;
+      writeFileSync(shimPath, content);
+      chmodSync(shimPath, 0o755);
+      console.log(`[Sandbox] Created shim for ${tool} at ${shimPath}`);
+    }
+  }
+}

--- a/src/sandbox/manager.ts
+++ b/src/sandbox/manager.ts
@@ -6,9 +6,9 @@ export class SandboxManager {
   private bridge: HostBridge;
   private workspacePath: string;
 
-  constructor(workspacePath: string) {
+  constructor(workspacePath: string, sandboxToken?: string) {
     this.workspacePath = workspacePath;
-    this.bridge = new HostBridge(workspacePath);
+    this.bridge = new HostBridge(workspacePath, sandboxToken);
   }
 
   async start() {

--- a/src/sandbox/shim.py
+++ b/src/sandbox/shim.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import socket
+import json
+import base64
+
+
+def main():
+    socket_path = os.environ.get("BRIDGE_SOCK", "./workspace/bridge.sock")
+    command = os.environ.get("SHIM_COMMAND", "gh")
+    args = sys.argv[1:]
+    cwd = os.getcwd()
+
+    req = {
+        "command": command,
+        "args": args,
+        "cwd": cwd,
+        "env": {"GH_TOKEN": os.environ.get("GH_TOKEN", "")},
+    }
+
+    try:
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.connect(socket_path)
+        client.sendall(json.dumps(req).encode("utf-8"))
+
+        # Read response
+        buffer = ""
+        while True:
+            data = client.recv(4096)
+            if not data:
+                break
+            buffer += data.decode("utf-8")
+
+            while "\n" in buffer:
+                line, buffer = buffer.split("\n", 1)
+                if not line.strip():
+                    continue
+                try:
+                    msg = json.loads(line)
+                    if msg["type"] == "stdout":
+                        sys.stdout.buffer.write(base64.b64decode(msg["data"]))
+                        sys.stdout.buffer.flush()
+                    elif msg["type"] == "stderr":
+                        sys.stderr.buffer.write(base64.b64decode(msg["data"]))
+                        sys.stderr.buffer.flush()
+                    elif msg["type"] == "exit":
+                        sys.exit(msg["code"])
+                    elif msg["type"] == "error":
+                        print(f"[Shim Error] {msg['message']}", file=sys.stderr)
+                        sys.exit(1)
+                except Exception as e:
+                    # Partial JSON or other error
+                    pass
+    except Exception as e:
+        print(f"[Shim] Failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sandbox/shim.ts
+++ b/src/sandbox/shim.ts
@@ -1,0 +1,62 @@
+import { connect } from 'bun';
+
+async function main() {
+  const socketPath = process.env.BRIDGE_SOCK || './workspace/bridge.sock';
+  const command = process.env.SHIM_COMMAND || 'gh';
+  const args = process.argv.slice(2);
+  const cwd = process.cwd();
+
+  console.error(`[Shim] Connecting to bridge at ${socketPath} for command ${command}...`);
+
+  try {
+    const socket = await connect({
+      unix: socketPath,
+      socket: {
+        data(socket, data) {
+          const lines = data.toString().split('\n');
+          for (const line of lines) {
+            if (!line.trim()) continue;
+            try {
+              const msg = JSON.parse(line);
+              if (msg.type === 'stdout') {
+                process.stdout.write(Buffer.from(msg.data, 'base64'));
+              } else if (msg.type === 'stderr') {
+                process.stderr.write(Buffer.from(msg.data, 'base64'));
+              } else if (msg.type === 'exit') {
+                process.exit(msg.code);
+              } else if (msg.type === 'error') {
+                console.error(`[Shim Error] ${msg.message}`);
+                process.exit(1);
+              }
+            } catch (e) {
+              // Handle potential partial JSON or multiple messages
+            }
+          }
+        },
+        error(socket, error) {
+          console.error(`[Shim] Connection error: ${error}`);
+          process.exit(1);
+        },
+        end(socket) {
+          // Connection closed
+        },
+      },
+    });
+
+    socket.write(
+      JSON.stringify({
+        command,
+        args,
+        cwd,
+        env: {
+          GH_TOKEN: process.env.GH_TOKEN, // In case it's needed, but ideally it's on host
+        },
+      }),
+    );
+  } catch (error) {
+    console.error(`[Shim] Failed to connect to bridge: ${error}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/sandbox/shim.ts
+++ b/src/sandbox/shim.ts
@@ -12,7 +12,7 @@ async function main() {
     const socket = await connect({
       unix: socketPath,
       socket: {
-        data(socket, data) {
+        data(_socket, data) {
           const lines = data.toString().split('\n');
           for (const line of lines) {
             if (!line.trim()) continue;
@@ -28,16 +28,16 @@ async function main() {
                 console.error(`[Shim Error] ${msg.message}`);
                 process.exit(1);
               }
-            } catch (e) {
+            } catch {
               // Handle potential partial JSON or multiple messages
             }
           }
         },
-        error(socket, error) {
+        error(_socket, error) {
           console.error(`[Shim] Connection error: ${error}`);
           process.exit(1);
         },
-        end(socket) {
+        end(_socket) {
           // Connection closed
         },
       },

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,7 +1,9 @@
 import { OpenCodeAgent, type OpenCodeEvent } from './opencode';
 import { MockProcess } from './mock';
-import { writeFileSync, readFileSync, existsSync } from 'fs';
+import { writeFileSync, readFileSync, existsSync, mkdirSync } from 'fs';
 import { type Agent } from './agent';
+import { SandboxManager } from './sandbox/manager';
+import { join } from 'path';
 
 const ANIMALS = [
   'panda',
@@ -132,9 +134,27 @@ export class SessionManager {
   private aliasToSession: Map<string, string> = new Map();
   private categoryId: string | null = null;
   private readonly PERSISTENCE_FILE: string;
+  private sandboxManager: SandboxManager | null = null;
+  private readonly workspacePath: string;
 
   constructor(persistenceFile: string = 'sessions.json') {
     this.PERSISTENCE_FILE = persistenceFile;
+    this.workspacePath = join(process.cwd(), 'workspace');
+    if (!existsSync(this.workspacePath)) {
+      mkdirSync(this.workspacePath, { recursive: true });
+    }
+
+    if (process.env.USE_SANDBOX === 'true') {
+      console.log('[Manager] Sandbox enabled. Initializing SandboxManager...');
+      this.sandboxManager = new SandboxManager(this.workspacePath);
+      this.sandboxManager.start();
+
+      // Setup shims for the sandbox user
+      // Assuming the sandbox user's bin dir is accessible or we put it in workspace
+      const sandboxBin = join(this.workspacePath, '.bin');
+      this.sandboxManager.setupShims(sandboxBin);
+    }
+
     this.loadPersistence();
   }
 
@@ -236,7 +256,20 @@ export class SessionManager {
 
   prepareSession(channelId: string, sessionId?: string): Agent {
     const sid = sessionId ? this.resolveSessionId(sessionId) : undefined;
-    const session = new OpenCodeAgent(sid);
+
+    // Determine the workspace for this session
+    const sessionWorkspace = sid
+      ? join(this.workspacePath, sid)
+      : join(this.workspacePath, `temp_${Date.now()}`);
+    if (!existsSync(sessionWorkspace)) {
+      mkdirSync(sessionWorkspace, { recursive: true });
+    }
+
+    const session = new OpenCodeAgent(sid, {
+      workspacePath: sessionWorkspace,
+      useSandbox: process.env.USE_SANDBOX === 'true',
+      sandboxBinDir: join(this.workspacePath, '.bin'),
+    });
     this.sessions.set(channelId, session);
 
     if (sid) {

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -146,7 +146,7 @@ export class SessionManager {
 
     if (process.env.USE_SANDBOX === 'true') {
       console.log('[Manager] Sandbox enabled. Initializing SandboxManager...');
-      this.sandboxManager = new SandboxManager(this.workspacePath);
+      this.sandboxManager = new SandboxManager(this.workspacePath, process.env.SANDBOX_GH_TOKEN);
       this.sandboxManager.start();
 
       // Setup shims for the sandbox user


### PR DESCRIPTION
## Summary
*   Implemented a **Host-Side Bridge Service** (`src/sandbox/bridge.ts`) that listens on a Unix Domain Socket and executes whitelisted commands (`gh`, `git`) on the host.
*   Implemented a **Generic Shim mechanism** using a Python script (`src/sandbox/shim.py`) that forwards commands from the sandbox to the host bridge.
*   Integrated `SandboxManager` into `SessionManager` to automatically start the bridge and set up shims in the sandbox's `PATH`.
*   Updated `OpenCodeAgent` to support sandboxed execution via `alclessctl` with shimmed tools.

## Why
This architecture ensures that sensitive secrets (like `GH_TOKEN`) never enter the sandbox environment. The sandboxed agent can use `gh` and `git` as usual, but it cannot leak the raw tokens because they stay in the host's memory/environment.

## Verification
1.  Run the host-shim verification script:
    ```bash
    bun scripts/verify-host-shim.ts
    ```
2.  The script will:
    *   Start the bridge on the host.
    *   Spawn a sandboxed process using `alclessctl`.
    *   Execute `gh auth status` via the shim.
    *   Verify that the output shows the host's auth status.
    *   Verify that `GH_TOKEN` is NOT present in the sandbox's environment.