### PR TITLE
PR #4: Bridge Integration with Mocked Agent

### DIFF
--- a/scripts/dumb-opencode.sh
+++ b/scripts/dumb-opencode.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# scripts/dumb-opencode.sh
+# A simple mock for the OpenCode binary that just runs shell commands
+# Expected args: run --format json [--session SID] "prompt"
+
+# Shift away the fixed args: run --format json
+shift 3
+
+# Check if there is a --session flag
+if [ "$1" == "--session" ]; then
+    SESSION_ID=$2
+    shift 2
+fi
+
+PROMPT="$1"
+
+# Output the "thinking" start event
+echo "{\"type\": \"step_start\"}"
+
+# Execute the command and capture output
+# We use eval or just sh -c to execute the prompt
+echo "{\"type\": \"text\", \"text\": \"[Sandbox Shell] Executing: $PROMPT\"}"
+
+RESULT=$(sh -c "$PROMPT" 2>&1)
+
+# Escape backslashes and quotes for JSON
+ESCAPED_RESULT=$(echo "$RESULT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
+
+echo "{\"type\": \"text\", \"text\": $ESCAPED_RESULT}"
+
+# Output the stop event
+echo "{\"type\": \"step_finish\", \"part\": {\"reason\": \"stop\"}}"

--- a/scripts/verify-discord-sandbox.ts
+++ b/scripts/verify-discord-sandbox.ts
@@ -1,0 +1,93 @@
+import { OpenCodeAgent } from '../src/opencode';
+import { join } from 'path';
+import { existsSync, mkdirSync, chmodSync, readFileSync, writeFileSync } from 'fs';
+
+async function main() {
+  console.log('--- Verifying Discord-Sandbox Integration with Dumb Shell ---');
+
+  const workspaceRoot = '/Users/Shared/workspace-test';
+  if (existsSync(workspaceRoot)) {
+    // Just ensure it's clean-ish
+    chmodSync(workspaceRoot, 0o777);
+  } else {
+    mkdirSync(workspaceRoot, { recursive: true });
+    chmodSync(workspaceRoot, 0o777);
+  }
+
+  const sessionId = 'test-animal-panda';
+  const sessionWorkspace = join(workspaceRoot, sessionId);
+  if (!existsSync(sessionWorkspace)) {
+    mkdirSync(sessionWorkspace);
+    chmodSync(sessionWorkspace, 0o777);
+  }
+
+  // Path to our dumb shell wrapper
+  const binDir = join(workspaceRoot, '.bin');
+  if (!existsSync(binDir)) {
+    mkdirSync(binDir, { recursive: true });
+    chmodSync(binDir, 0o777);
+  }
+
+  const dumbShellPath = join(binDir, 'opencode');
+  const sourceShellPath = join(process.cwd(), 'scripts/dumb-opencode.sh');
+  const scriptContent = readFileSync(sourceShellPath);
+  writeFileSync(dumbShellPath, scriptContent);
+  chmodSync(dumbShellPath, 0o755);
+
+  process.env.OPENCODE_BINARY = dumbShellPath;
+
+  const agent = new OpenCodeAgent(sessionId, {
+    workspacePath: sessionWorkspace,
+    useSandbox: true,
+    sandboxBinDir: binDir,
+  });
+
+  console.log('1. Testing basic command execution (whoami)...');
+  let output = '';
+  agent.on('output', (text) => {
+    output += text;
+  });
+  agent.on('stderr', (text) => {
+    console.error(`[Agent Stderr] ${text}`);
+  });
+
+  await agent.start('whoami');
+
+  console.log(`Output: ${output}`);
+  if (output.includes('alcless_')) {
+    console.log('Success: Running as sandbox user.');
+  } else {
+    console.error('Failure: Not running as sandbox user.');
+    process.exit(1);
+  }
+
+  console.log('\n2. Testing workspace mapping (pwd)...');
+  output = '';
+  await agent.start('pwd');
+  console.log(`Output: ${output}`);
+  if (output.includes(sessionId)) {
+    console.log('Success: CWD is in the session workspace.');
+  } else {
+    console.error('Failure: CWD is incorrect.');
+    process.exit(1);
+  }
+
+  console.log('\n3. Testing persistence and write access...');
+  await agent.start('echo "Persisted Content" > verified.txt');
+
+  // Check on host if file exists
+  const hostFilePath = join(sessionWorkspace, 'verified.txt');
+  if (existsSync(hostFilePath)) {
+    const content = readFileSync(hostFilePath, 'utf-8');
+    console.log(`Success: File created on host at ${hostFilePath}`);
+    console.log(`Content: ${content.trim()}`);
+  } else {
+    console.error('Failure: File was not created in workspace.');
+    process.exit(1);
+  }
+
+  console.log('\n--- Verification Complete ---');
+  process.exit(0);
+}
+
+main();

--- a/src/opencode.ts
+++ b/src/opencode.ts
@@ -76,16 +76,25 @@ export class OpenCodeAgent extends EventEmitter implements Agent {
 
     if (this.useSandbox) {
       // Wrap with alclessctl
-      // We use --plain to avoid rsyncing, and manage the workspace manually
+      // We use --plain to avoid rsyncing, and manage the workspace manually via --workdir
+      // We escape each argument for sh -c
+      const escapedArgs = args
+        .map((a) => {
+          // Escape single quotes for the sh -c string
+          return "'" + a.replace(/'/g, "'\\''") + "'";
+        })
+        .join(' ');
+
       const sandboxCommand = [
         'alclessctl',
         'shell',
         '--plain',
+        '--workdir',
+        this.workspacePath,
         'default',
-        '--',
         'sh',
         '-c',
-        `cd "${this.workspacePath}" && export PATH="${this.sandboxBinDir}:$PATH" && "${commandPath}" ${args.map((a) => `"${a}"`).join(' ')}`,
+        `export PATH="${this.sandboxBinDir}:$PATH" && "${commandPath}" ${escapedArgs}`,
       ];
       spawnArgs = sandboxCommand;
       console.log(`[Agent] Sandboxed Spawning: ${spawnArgs.join(' ')}`);


### PR DESCRIPTION
## Summary
*   Implemented `scripts/dumb-opencode.sh`, a mock agent that executes raw shell commands but satisfies the OpenCode JSON event interface.
*   Updated `OpenCodeAgent` to use `alclessctl shell --workdir` for robust sandboxed execution and proper argument escaping.
*   Enhanced `SessionManager` to handle workspace directory creation and permissions in `/Users/Shared/discobot-workspace` (to avoid macOS home directory permission issues).
*   Verified the full loop from Agent to Sandbox with a new verification script.

## Verification
1.  Run the Discord-Sandbox loop verification:
    ```bash
    bun scripts/verify-discord-sandbox.ts
    ```
2.  The script verifies:
    *   Execution as the sandbox user.
    *   Correct mapping of session-specific subdirectories.
    *   Persistence and write access within the sandbox.
3.  You can also run the bot with `OPENCODE_BINARY=./scripts/dumb-opencode.sh USE_SANDBOX=true bun index.ts` and test commands directly from Discord.