### PR TITLE
PR #5: Workspace Logic & Persistence

### DIFF
--- a/scripts/verify-workspace-binding.ts
+++ b/scripts/verify-workspace-binding.ts
@@ -1,0 +1,62 @@
+import { SessionManager } from '../src/sessions';
+import { join } from 'path';
+import { existsSync, rmSync } from 'fs';
+
+async function main() {
+  console.log('--- Verifying Workspace Binding Logic ---');
+
+  const dbPath = 'test-sessions-binding.json';
+  if (existsSync(dbPath)) rmSync(dbPath);
+
+  const manager = new SessionManager(dbPath);
+  const channelId = '123456789012345678';
+  const folderName = 'verification-project';
+
+  console.log(`1. Binding channel ${channelId} to folder "${folderName}"...`);
+  const bound = manager.bindChannelToFolder(channelId, folderName);
+
+  if (bound === folderName) {
+    console.log('Success: Folder name sanitized and returned correctly.');
+  } else {
+    console.error('Failure: Unexpected sanitized name.');
+    process.exit(1);
+  }
+
+  console.log('2. Preparing session for bound channel...');
+  const agent = manager.prepareSession(channelId) as unknown as { workspacePath: string };
+
+  const expectedPath = join(manager['workspacePath'], folderName);
+  console.log(`Expected Workspace: ${expectedPath}`);
+  console.log(`Actual Workspace:   ${agent.workspacePath}`);
+
+  if (agent.workspacePath === expectedPath) {
+    console.log('Success: Agent is using the bound folder.');
+  } else {
+    console.error('Failure: Agent is NOT using the bound folder.');
+    process.exit(1);
+  }
+
+  if (existsSync(expectedPath)) {
+    console.log('Success: Workspace folder was created on disk.');
+  } else {
+    console.error('Failure: Workspace folder was NOT created.');
+    process.exit(1);
+  }
+
+  console.log('3. Verifying persistence of binding...');
+  const manager2 = new SessionManager(dbPath);
+  const bound2 = manager2.getBinding(channelId);
+
+  if (bound2 === folderName) {
+    console.log('Success: Binding persisted in sessions.json.');
+  } else {
+    console.error('Failure: Binding did NOT persist.');
+    process.exit(1);
+  }
+
+  console.log('\n--- Verification Complete ---');
+  if (existsSync(dbPath)) rmSync(dbPath);
+  process.exit(0);
+}
+
+main();

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -326,6 +326,31 @@ export class DiscordClient {
           break;
         }
 
+        case 'bind': {
+          const folder = options.getString('folder');
+          if (!folder) {
+            await interaction.reply({
+              content: '❌ **Error**: Please provide a folder name.',
+              flags: [MessageFlags.Ephemeral],
+            });
+            return;
+          }
+
+          try {
+            const sanitized = this.sessionManager.bindChannelToFolder(channelId, folder);
+            await interaction.reply({
+              content: `✅ **Bound channel to folder:** \`${sanitized}\` in the workspace.\nAll subsequent commands will run in this directory.`,
+            });
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            await interaction.reply({
+              content: `❌ **Error**: ${errorMessage}`,
+              flags: [MessageFlags.Ephemeral],
+            });
+          }
+          break;
+        }
+
         case 'resume': {
           const sessionId = options.getString('session_id');
           if (!sessionId) {
@@ -650,6 +675,15 @@ export class DiscordClient {
       new SlashCommandBuilder()
         .setName('restart')
         .setDescription('Restart the session in this channel (wipe history)'),
+      new SlashCommandBuilder()
+        .setName('bind')
+        .setDescription('Bind this channel to a specific workspace folder')
+        .addStringOption((option) =>
+          option
+            .setName('folder')
+            .setDescription('The name of the folder in the workspace')
+            .setRequired(true),
+        ),
     ].map((command) => command.toJSON());
 
     const rest = new REST({ version: '10' }).setToken(this.token);


### PR DESCRIPTION
## Summary
*   Implemented **Repository Binding**: Introduced the `/bind` command to link a Discord channel to a specific folder name in the workspace.
*   Updated `SessionManager` to respect these bindings, allowing multiple channels to point to the same repository folder or separate project spaces.
*   Added sanitization to bound folder names to prevent path traversal or invalid directory names.
*   Verified that bindings persist across bot restarts via `sessions.json`.

## Verification
1.  Run the binding verification script:
    ```bash
    bun scripts/verify-workspace-binding.ts
    ```
2.  The script confirms:
    *   Binding a channel to a custom folder name.
    *   Preparing a session correctly points the agent to that folder.
    *   The binding persists after re-initializing the `SessionManager`.