### PR TITLE
Message splitting and tiered summarization

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -54,7 +54,7 @@ This project aims to build a portable bridge between Discord and multiple `openc
   - [x] Fix JSON parser hang on tool outputs with braces.
 - [x] **Phase 9: Response Optimization & Interactivity**
   - [x] Implement Direct Stream architecture (Pipe-based).
-  - [x] Implement silent summarization loop for messages > 2000 chars.
+  - [x] Implement tiered message handling (Split up to 9,500 chars, then summarize).
   - [x] Enhance terminal logging for tool usage and context processing.
   - [x] Single updating 'Still thinking' message with elapsed time.
   - [x] Remove "Using tool..." UI noise (and fix regression in #9).

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -158,10 +158,7 @@ describe('Integration: Full Flow', () => {
       await new Promise((r) => setTimeout(r, 20));
     }
 
-    expect(mockProcess.start).toHaveBeenCalledWith(expect.stringContaining('Hello agent!'));
-    expect(mockProcess.start).toHaveBeenCalledWith(
-      expect.stringContaining('Be concise and stay under 1800 chars'),
-    );
+    expect(mockProcess.start).toHaveBeenCalledWith('Hello agent!');
     expect(mockMessage.react).toHaveBeenCalledWith('📥');
   });
 });

--- a/src/message_splitting.test.ts
+++ b/src/message_splitting.test.ts
@@ -1,0 +1,106 @@
+import { expect, test, describe, mock, spyOn, afterAll } from 'bun:test';
+import { DiscordClient, type Config } from './discord';
+import { EventEmitter } from 'events';
+import { unlinkSync, existsSync } from 'fs';
+
+const TEST_DB = 'sessions.test_split.json';
+
+const mockConfig: Config = {
+  discord: {
+    token: 'test-token',
+    clientId: 'test-client-id',
+    guildId: 'test-guild-id',
+    sessionDb: TEST_DB,
+  },
+  sandbox: {
+    enabled: true,
+    workspaceDir: './workspace-test',
+    sandboxGhToken: 'test-gh-token',
+    opencodeConfigPath: './opencode.json',
+  },
+};
+
+describe('DiscordClient Message Splitting', () => {
+  afterAll(() => {
+    if (existsSync(TEST_DB)) unlinkSync(TEST_DB);
+  });
+
+  test('should send small message directly', async () => {
+    const client = new DiscordClient(mockConfig);
+    const mockChannel = {
+      id: 'chan1',
+      send: mock(async () => ({})),
+      sendTyping: mock(async () => {}),
+    } as any;
+    const mockAgent = new EventEmitter() as any;
+    mockAgent.getStdoutPath = () => '';
+    mockAgent.getStderrPath = () => '';
+
+    (client as any).attachSessionListeners(mockAgent, mockChannel);
+
+    mockAgent.emit('output', 'hello');
+
+    // Small delay to allow async handlers to run
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockChannel.send).toHaveBeenCalledWith('hello');
+  });
+
+  test('should split medium message (1900-9500)', async () => {
+    const client = new DiscordClient(mockConfig);
+    const mockChannel = {
+      id: 'chan2',
+      send: mock(async () => ({})),
+      sendTyping: mock(async () => {}),
+    } as any;
+    const mockAgent = new EventEmitter() as any;
+    mockAgent.getStdoutPath = () => '';
+    mockAgent.getStderrPath = () => '';
+
+    (client as any).attachSessionListeners(mockAgent, mockChannel);
+
+    // 3000 chars should be 2 messages (1900 + 1100)
+    const longMessage = 'a'.repeat(3000);
+    mockAgent.emit('output', longMessage);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockChannel.send).toHaveBeenCalledTimes(2);
+    expect(mockChannel.send.mock.calls[0][0]).toContain('[1/2]');
+    expect(mockChannel.send.mock.calls[1][0]).toContain('[2/2]');
+  });
+
+  test('should trigger summarization for very long message (>9500)', async () => {
+    const client = new DiscordClient(mockConfig);
+    const mockChannel = {
+      id: 'chan3',
+      send: mock(async () => ({})),
+      sendTyping: mock(async () => {}),
+    } as any;
+
+    const mockAgent = new EventEmitter() as any;
+    mockAgent.getStdoutPath = () => '';
+    mockAgent.getStderrPath = () => '';
+    mockAgent.start = mock(async () => {});
+
+    // Mock prepareSession to return another mock agent
+    spyOn((client as any).sessionManager, 'prepareSession').mockReturnValue(mockAgent);
+
+    (client as any).attachSessionListeners(mockAgent, mockChannel);
+
+    const hugeMessage = 'a'.repeat(10000);
+    mockAgent.emit('output', hugeMessage);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Should NOT send the huge message directly
+    const sentMessages = mockChannel.send.mock.calls.map((c: any) => c[0]);
+    expect(sentMessages).not.toContain(hugeMessage);
+
+    // Should have triggered a new session with summarization prompt
+    expect(mockAgent.start).toHaveBeenCalled();
+    const prompt = mockAgent.start.mock.calls[0][0];
+    expect(prompt).toContain('too long');
+    expect(prompt).toContain('9500');
+  });
+});

--- a/src/opencode.ts
+++ b/src/opencode.ts
@@ -8,6 +8,12 @@ export interface OpenCodeEvent {
   text?: string;
   sessionID?: string;
   tool?: string;
+  error?: {
+    message?: string;
+    data?: {
+      message?: string;
+    };
+  };
   part?: {
     type: string;
     text?: string;
@@ -17,6 +23,8 @@ export interface OpenCodeEvent {
     state?: {
       input?: unknown;
       output?: unknown;
+      status?: string;
+      error?: string;
     };
   };
 }


### PR DESCRIPTION
## Summary
Implemented tiered message handling for Discord outputs to handle long agent responses more gracefully.

### Key Changes
- **Message Splitting**: Outputs between 1,900 and 9,500 characters are now split into multiple messages (up to 5 chunks) with a `[n/total]` prefix.
- **Tiered Summarization**: The automatic summarization loop is now only triggered for outputs exceeding 9,500 characters.
- **Prompt Simplification**: Removed aggressive sanitization and fixed instructions from the initial prompt to the agent, allowing for more natural interactions.
- **Error Handling**: Enhanced `OpenCodeEvent` interface to better capture tool errors and status updates.
- **Testing**: Added a new test suite `src/message_splitting.test.ts` to verify splitting logic and summarization triggers.

### Technical Details
- `CHUNK_SIZE` set to 1,900 to stay safely under Discord's 2,000-character limit.
- `MAX_CHUNKS` set to 5, resulting in a `MAX_TOTAL_LENGTH` of 9,500 characters before summarization kicks in.
- Added a truncation warning if the output exceeds `MAX_CHUNKS` but hasn't yet reached the summarization threshold.