### PR TITLE
Override agent output restrictions via dynamic prompt patching

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -74,6 +74,7 @@ This project aims to build a portable bridge between Discord and multiple `openc
   - [x] Implement persistent mode tracking in `SessionManager` (TASKS_031).
   - [x] Add `/mode` slash command and `!mode` shortcuts.
   - [x] Pass mode flags to `OpenCodeAgent` process.
+  - [x] Implement dynamic system prompt patching to override output restrictions.
 
 ## Setup Requirements (Preview)
 

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -389,6 +389,22 @@ export class SessionManager {
           const path = p === 'google' ? '/google' : `/${p}`;
           config.provider[p].options.baseURL = `http://127.0.0.1:${sandboxLocalPort}${path}`;
         }
+
+        // Bridge Capability Patch: Override 1800 char restriction in agent prompts
+        const capabilityNote =
+          '\n\nNote: The Discord bridge now supports responses up to 9,500 characters (automatically split into multiple messages). You are no longer restricted to 1,800 characters. If you have data to show, you can show it directly without aggressive summarization.';
+        if (config.agent) {
+          for (const name of Object.keys(config.agent)) {
+            const agent = config.agent[name];
+            if (agent && typeof agent.prompt === 'string') {
+              // Only append if not already present
+              if (!agent.prompt.includes('no longer restricted to 1,800 characters')) {
+                agent.prompt += capabilityNote;
+              }
+            }
+          }
+        }
+
         writeFileSync(join(sandboxConfigDir, 'opencode.json'), JSON.stringify(config, null, 2));
       } catch {
         copyFileSync(hostConfigPath, join(sandboxConfigDir, 'opencode.json'));


### PR DESCRIPTION
## Summary
This PR fixes an issue where the agent would refuse to provide large outputs due to historical instructions ("stay under 1800 chars") preserved in session context.

## Key Changes
- **Dynamic Prompt Patching**: Appends a "Bridge Capability Note" to all agent system prompts in `prepareSession`.
- **Instruction Override**: Explicitly informs the agent that the Discord bridge now supports up to 9,500 characters and handles message splitting automatically.
- **Improved Transparency**: Encourages the agent to show data directly instead of aggressive summarization when appropriate.

## Verification
- Verified that existing sessions (like `tiger`) correctly receive the updated system prompt.
- Verified that all linting and existing tests pass.